### PR TITLE
Re-enable fix-permissions script

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -23,7 +23,6 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf $HOME/.pki && \
     (curl -L https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz | \
         tar -xz -C /usr/local)
 

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -23,7 +23,6 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf $HOME/.pki && \
     (curl -L https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz | \
         tar -xz -C /usr/local)
 

--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -23,7 +23,6 @@ RUN yum install -y centos-release-scl && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum clean all -y && \
-    rm -rf $HOME/.pki && \
     (curl -L https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz | \
         tar -xz -C /usr/local)
 

--- a/s2i/assemble
+++ b/s2i/assemble
@@ -30,8 +30,5 @@ go install main
 echo
 echo "===> Build completed at $(date)"
 
-# TODO: re-enable this once this issue is resolved:
-# https://github.com/openshift/sti-python/issues/60
-#
 # Fix source directory permissions
-#fix-permissions ./
+fix-permissions ./


### PR DESCRIPTION
The permissions of the .pki directory have been fixed in the sti-base
image (see openshift/sti-base@1135b0d)

This change re-enables the fix-permissions script and removes the
temporary hack (removing the .pki directory during the Docker image
build.)

Signed-off-by: Jonathan Yu jawnsy@redhat.com
