### PR TITLE
Parse command-line flags during initialization

### DIFF
--- a/1.4/test/test-app/main.go
+++ b/1.4/test/test-app/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/golang/glog"
 	"net/http"
@@ -18,6 +19,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
+
 	glog.Info("Starting server...")
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":8080", nil)

--- a/1.5/test/test-app/main.go
+++ b/1.5/test/test-app/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/golang/glog"
 	"net/http"
@@ -18,6 +19,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
+
 	glog.Info("Starting server...")
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":8080", nil)

--- a/1.6/test/test-app/main.go
+++ b/1.6/test/test-app/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/golang/glog"
 	"net/http"
@@ -18,6 +19,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Parse()
+
 	glog.Info("Starting server...")
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":8080", nil)


### PR DESCRIPTION
We need to invoke flag.Parse() to avoid warnings from glog.

Signed-off-by: Jonathan Yu jawnsy@redhat.com
