### PR TITLE
Bash script a bit more compatible

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -82,7 +82,7 @@ for dir in ${dirs}; do
 
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ -n "${TEST_MODE}" ]]; then
     IMAGE_NAME+="-candidate"
   fi
 
@@ -95,7 +95,7 @@ for dir in ${dirs}; do
     docker_build_with_version Dockerfile
   fi
 
-  if [[ -v TEST_MODE ]]; then
+  if [[ -n "${TEST_MODE}" ]]; then
     IMAGE_NAME=${IMAGE_NAME} test/run
 
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then


### PR DESCRIPTION
- Fixes openshift-s2i/s2i-go#5
- Uses the `-n` option as it's well documented and used cross platform
