### PR TITLE
Clean up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 services:
   - docker
 
+env:
+- VERSION=1.4
+- VERSION=1.5
+- VERSION=1.6
+
 before_install:
   # Download and install source-to-image (S2I)
   - mkdir $HOME/.bin

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -56,13 +56,13 @@ function docker_build_with_version {
 }
 
 # Install the docker squashing tool[1] and squash the result image
-# [1] https://github.com/goldmann/docker-scripts
+# [1] https://github.com/goldmann/docker-squash
 function squash {
   # FIXME: We have to use the exact versions here to avoid Docker client
   #        compatibility issues
-  easy_install -q --user docker_py==1.6.0 docker-scripts==0.4.4
+  easy_install -q --user docker_py==1.7.2 docker-squash==1.0.4
   base=$(awk '/^FROM/{print $2}' $1)
-  ${HOME}/.local/bin/docker-scripts squash -f $base ${IMAGE_NAME}
+  ${HOME}/.local/bin/docker-squash -f $base ${IMAGE_NAME}
 }
 
 # Versions are stored in subdirectories. You can specify VERSION variable


### PR DESCRIPTION
* Updates `docker-squash` so that Travis builds will pass again (due to updated Docker).
  If this is problematic, I can switch this so instead we downgrade Docker on start, but I believe RHEL7/CentOS7 both ship with Docker 1.7+, so we should be fine, but I need someone else to check.
* Sets `sudo: required`. This isn't strictly necessary, since Travis will force this anyway if you have `services: - docker`, but it's more consistent with what's actually happening.
* Parallelize Travis builds by building all of the Go versions simultaneously in different jobs. This speeds up Go builds by 3x.