### PR TITLE
make s2i scripts available in each contextdir

### DIFF
--- a/1.4/s2i/bin/assemble
+++ b/1.4/s2i/bin/assemble
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+echo
+echo "===> Build started at $(date)"
+echo
+START=$SECONDS
+
+# Unconditionally print elapsed build time at exit
+function finish {
+  echo "===> Elapsed time: $(($SECONDS - $START)) seconds"
+}
+trap finish EXIT
+
+echo "---> Preparing source..."
+mkdir -p $SOURCE
+
+cp -Rf /tmp/src/. $SOURCE
+
+cd $SOURCE
+
+echo "---> Downloading dependencies..."
+go get -v ./...
+
+echo "---> Building application source..."
+go build -v -o main
+go install main
+
+echo
+echo "===> Build completed at $(date)"
+
+# Fix source directory permissions
+fix-permissions ./

--- a/1.4/s2i/bin/run
+++ b/1.4/s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec $GOBIN/main

--- a/1.4/s2i/bin/usage
+++ b/1.4/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+IMAGEVER=$($GO_VERSION | sed s/\.//)
+
+cat <<EOF
+This is a S2I Go $GO_VERSION CentOS base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+$ s2i build https://github.com/openshift-s2i/s2i-go.git \\
+    --context-dir=/${GO_VERSION}/test/test-app/ openshift/go-${IMAGEVER}-centos7 go-test-app
+
+You can then run the resulting image via:
+
+$ docker run -p 8080:8080 go-test-app
+EOF

--- a/1.5/s2i/bin/assemble
+++ b/1.5/s2i/bin/assemble
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+echo
+echo "===> Build started at $(date)"
+echo
+START=$SECONDS
+
+# Unconditionally print elapsed build time at exit
+function finish {
+  echo "===> Elapsed time: $(($SECONDS - $START)) seconds"
+}
+trap finish EXIT
+
+echo "---> Preparing source..."
+mkdir -p $SOURCE
+
+cp -Rf /tmp/src/. $SOURCE
+
+cd $SOURCE
+
+echo "---> Downloading dependencies..."
+go get -v ./...
+
+echo "---> Building application source..."
+go build -v -o main
+go install main
+
+echo
+echo "===> Build completed at $(date)"
+
+# Fix source directory permissions
+fix-permissions ./

--- a/1.5/s2i/bin/run
+++ b/1.5/s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec $GOBIN/main

--- a/1.5/s2i/bin/usage
+++ b/1.5/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+IMAGEVER=$($GO_VERSION | sed s/\.//)
+
+cat <<EOF
+This is a S2I Go $GO_VERSION CentOS base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+$ s2i build https://github.com/openshift-s2i/s2i-go.git \\
+    --context-dir=/${GO_VERSION}/test/test-app/ openshift/go-${IMAGEVER}-centos7 go-test-app
+
+You can then run the resulting image via:
+
+$ docker run -p 8080:8080 go-test-app
+EOF

--- a/1.6/s2i/bin/assemble
+++ b/1.6/s2i/bin/assemble
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+echo
+echo "===> Build started at $(date)"
+echo
+START=$SECONDS
+
+# Unconditionally print elapsed build time at exit
+function finish {
+  echo "===> Elapsed time: $(($SECONDS - $START)) seconds"
+}
+trap finish EXIT
+
+echo "---> Preparing source..."
+mkdir -p $SOURCE
+
+cp -Rf /tmp/src/. $SOURCE
+
+cd $SOURCE
+
+echo "---> Downloading dependencies..."
+go get -v ./...
+
+echo "---> Building application source..."
+go build -v -o main
+go install main
+
+echo
+echo "===> Build completed at $(date)"
+
+# Fix source directory permissions
+fix-permissions ./

--- a/1.6/s2i/bin/run
+++ b/1.6/s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec $GOBIN/main

--- a/1.6/s2i/bin/usage
+++ b/1.6/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+IMAGEVER=$($GO_VERSION | sed s/\.//)
+
+cat <<EOF
+This is a S2I Go $GO_VERSION CentOS base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+$ s2i build https://github.com/openshift-s2i/s2i-go.git \\
+    --context-dir=/${GO_VERSION}/test/test-app/ openshift/go-${IMAGEVER}-centos7 go-test-app
+
+You can then run the resulting image via:
+
+$ docker run -p 8080:8080 go-test-app
+EOF

--- a/1.7/s2i/bin/assemble
+++ b/1.7/s2i/bin/assemble
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+echo
+echo "===> Build started at $(date)"
+echo
+START=$SECONDS
+
+# Unconditionally print elapsed build time at exit
+function finish {
+  echo "===> Elapsed time: $(($SECONDS - $START)) seconds"
+}
+trap finish EXIT
+
+echo "---> Preparing source..."
+mkdir -p $SOURCE
+
+cp -Rf /tmp/src/. $SOURCE
+
+cd $SOURCE
+
+echo "---> Downloading dependencies..."
+go get -v ./...
+
+echo "---> Building application source..."
+go build -v -o main
+go install main
+
+echo
+echo "===> Build completed at $(date)"
+
+# Fix source directory permissions
+fix-permissions ./

--- a/1.7/s2i/bin/run
+++ b/1.7/s2i/bin/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec $GOBIN/main

--- a/1.7/s2i/bin/usage
+++ b/1.7/s2i/bin/usage
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+IMAGEVER=$($GO_VERSION | sed s/\.//)
+
+cat <<EOF
+This is a S2I Go $GO_VERSION CentOS base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+$ s2i build https://github.com/openshift-s2i/s2i-go.git \\
+    --context-dir=/${GO_VERSION}/test/test-app/ openshift/go-${IMAGEVER}-centos7 go-test-app
+
+You can then run the resulting image via:
+
+$ docker run -p 8080:8080 go-test-app
+EOF


### PR DESCRIPTION
Fixes #18 

Instead of using `s2i` command, I use buildconfigs and imagestreams in a shared project to maintain builder images. This patch copies the s2i scripts to each versioned context dir so that may be accommodated.

**eg:**

```yaml
---
kind: ImageStreamList
apiVersion: v1
metadata: {}

items:
- kind: ImageStream
  apiVersion: v1
  metadata:
    name: go
  spec:
    tags:
    - name: latest
      annotations:
        description: Build and run Go (latest) applications
        iconClass: icon-golang
        tags: builder,golang,go,dlbewley
        supports: go,golang
        sampleRepo: https://github.com/dlbewley/go-ex.git
      from:
        kind: ImageStreamTag
        name: '1.7'
```

```yaml
---
kind: BuildConfigList
apiVersion: v1
metadata: {}
items:
- kind: BuildConfig
  metadata:
    name: go-17-centos7
    annotations:
      description: Defines how to build go-17-centos7 s2i builder image
      tags: dlbewley
  spec:
    output:
      to:
        kind: ImageStreamTag
        name: go:1.7
    source:
      git:
        uri: https://github.com/dlbewley/s2i-go.git
        ref: issue18
      type: Git
      contextDir: "1.7"
    strategy:
      type: Docker
      dockerStrategy:
        noCache: true
    triggers:
    - type: "imagechange"
      imageChange:
        from:
          kind: "ImageStreamTag"
          name: "openshift/base-centos7:latest"
```


BTW, This pattern is also present in https://github.com/sclorg/s2i-python-container