### PR TITLE
Add OpenShift image-streams (template)

### DIFF
--- a/image-streams-centos7.json
+++ b/image-streams-centos7.json
@@ -1,0 +1,100 @@
+{
+  "kind": "ImageStreamList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "ImageStream",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "go",
+        "annotations": {
+          "openshift.io/display-name": "Go"
+        }
+      },
+      "spec": {
+        "tags": [
+          {
+            "name": "latest",
+            "annotations": {
+              "openshift.io/display-name": "Go (Latest)",
+              "description": "Build and run Go applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/tree/master/2.3/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Ruby available on OpenShift, including major versions updates.",
+              "iconClass": "icon-go-gopher",
+              "tags": "builder,go",
+              "supports": "go",
+              "sampleRepo": "https://github.com/openshift-s2i/s2i-go.git"
+            },
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "1.7"
+            }
+          },
+          {
+            "name": "1.4",
+            "annotations": {
+              "openshift.io/display-name": "Go 1.4",
+              "description": "Build and run Go 1.4 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-go",
+              "iconClass": "icon-go-gopher",
+              "tags": "hidden,builder,go",
+              "supports": "go:1.4,go",
+              "version": "1.4",
+              "sampleRepo": "https://github.com/openshift-s2i/s2i-go.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/go-14-centos7:latest"
+            }
+          },
+          {
+            "name": "1.5",
+            "annotations": {
+              "openshift.io/display-name": "Go 1.5",
+              "description": "Build and run Go 1.5 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-go",
+              "iconClass": "icon-go-gopher",
+              "tags": "hidden,builder,go",
+              "supports": "go:1.5,go",
+              "version": "1.5",
+              "sampleRepo": "https://github.com/openshift-s2i/s2i-go.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/go-15-centos7:latest"
+            }
+          },
+          {
+            "name": "1.6",
+            "annotations": {
+              "openshift.io/display-name": "Go 1.6",
+              "description": "Build and run Go 1.6 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-go",
+              "iconClass": "icon-go-gopher",
+              "tags": "hidden,builder,go",
+              "supports": "go:1.6,go",
+              "version": "1.6",
+              "sampleRepo": "https://github.com/openshift-s2i/s2i-go.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/go-16-centos7:latest"
+            }
+          },
+          {
+            "name": "1.7",
+            "annotations": {
+              "openshift.io/display-name": "Go 1.7",
+              "description": "Build and run Go 1.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-go",
+              "iconClass": "icon-go-gopher",
+              "tags": "builder,go",
+              "supports": "go:1.7,go",
+              "version": "1.7",
+              "sampleRepo": "https://github.com/openshift-s2i/s2i-go.git"
+            },
+            "from": {
+              "kind": "DockerImage",
+              "name": "openshift/go-17-centos7:latest"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This allows easy deployment of go apps from the web interface. #7

It's a modified copy of the default ruby imagestreams so descriptions might need to be revised.

Just run `oc -n openshift create -f image-streams-centos7.json` to import the template into all projects.

Since `openshift/go-17-centos7:latest` is not published on docker #10 it is neccessary to build and push the image manually to the registry. To do that the simplest thing is to got go to the default project click on the route to the registry console. login. then there is a command to login to the registry (it might be neccessary to add the ca certificate to the system). After the image-streams are created they show up in the registry console with instructions on how to push the images.

The samplerepo does not add a context dir so it does not work as is when clicking try it.
